### PR TITLE
基于范例的“拼音风格”命令行选项

### DIFF
--- a/pinyin/main.go
+++ b/pinyin/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	heteronym := flag.Bool("e", false, "启用多音字模式")
-	style := flag.String("s", "Tone", "指定拼音风格。可选值：Normal, Tone, Tone2, Tone3, Initials, FirstLetter, Finals, FinalsTone, FinalsTone2, FinalsTone3")
+	style := flag.String("s", "zh4ao", "指定拼音风格。可选值：zhao, zh4ao, zha4o, zhao4, zh, z, ao, 4ao, a4o, ao4")
 	flag.Parse()
 	hans := flag.Args()
 	stdin := []byte{}
@@ -34,23 +34,23 @@ func main() {
 		args.Heteronym = true
 	}
 	switch *style {
-	case "Normal":
+	case "zhao":
 		args.Style = pinyin.Normal
-	case "Tone2":
+	case "zha4o":
 		args.Style = pinyin.Tone2
-	case "Tone3":
+	case "zhao4":
 		args.Style = pinyin.Tone3
-	case "Initials":
+	case "zh":
 		args.Style = pinyin.Initials
-	case "FirstLetter":
+	case "z":
 		args.Style = pinyin.FirstLetter
-	case "Finals":
+	case "ao":
 		args.Style = pinyin.Finals
-	case "FinalsTone":
+	case "4ao":
 		args.Style = pinyin.FinalsTone
-	case "FinalsTone2":
+	case "a4o":
 		args.Style = pinyin.FinalsTone2
-	case "FinalsTone3":
+	case "ao4":
 		args.Style = pinyin.FinalsTone3
 	default:
 		args.Style = pinyin.Tone


### PR DESCRIPTION
实用工具pinyin目前直接采用源代码定义的拼音风格名作为命令行选项，似乎存在以下问题：

- 选项名过长，且大小写字母数字混合，拼写不便。一般来说，命令行选项极少采用upper camel casing的形式，即使简单地`strconv.ToLower()`一下再比较，用户体验也会好一些。
- 命名略显仓促，用户难以记忆，代码难以重构和扩展。例如，`Normal`改称`Toneless`似乎更精确；哪些风格带有复数s，什么是2什么是3，为什么没有1，用户回忆起来恐怕也得“顿一下”。

如果仅作为第三方库给悲催的程序员调用，以上问题（除了代码维护）似乎也无所谓。但既然提供了命令行工具，个人倾向于对用户更温柔些。

在此建议改用基于范例的风格选项，好处是：容易拼写，也容易记忆；用户注意力集中到问题域，不容易写错；隐藏了实现方式，利于代码维护；容易基于现有代码修改，不易改错。

建议采用的范例字是“赵”，好处是：好记（百家姓首位）；拼音短；涵盖了现有的全部风格；挺欢乐……

对应如下：

拼音风格 | 命令行选项 | 附注
--- | --- | ---
Normal | zhao |
Tone | zh4ao | *
Tone2 | zha4o |
Tone3 | zhao4 |
Initials | zh |
FirstLetter | z |
Finals | ao |
FinalsTone | 4ao | *
FinalsTone2 | a4o |
FinalsTone3 | ao4 |

附注标*处的说明：zhào和ào不容易输入，命令行选项就要采取折衷，这是用户唯一需要“硬记”的地方。其中Tone是默认选项，一般不需要指定；必须指定时，也只要记得“4在a前面”（for all?），这也是a4o、ao4的自然外推。