### PR TITLE
Update the cli installation command for go 1.17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ go get -u github.com/mozillazg/go-pinyin
 install CLI tool:
 
 ```
+# go version>=1.17
+go install github.com/mozillazg/go-pinyin/cmd/pinyin@latest
+
+# go version<1.17
 go get -u github.com/mozillazg/go-pinyin/cmd/pinyin
+
 $ pinyin 中国人
 zhōng guó rén
 ```
@@ -87,7 +92,7 @@ func main() {
   详见 [示例](https://godoc.org/github.com/mozillazg/go-pinyin#example-Pinyin--FallbackCustom1)）。
 * 根据 [《汉语拼音方案》](http://www.moe.gov.cn/s78/A19/yxs_left/moe_810/s230/195802/t19580201_186000.html) y，w，ü (yu) 都不是声母，
   以及不是所有拼音都有声母，如果这不是你预期的话，你可能需要的是首字母风格 `FirstLetter`
-（ [详细信息](https://github.com/mozillazg/python-pinyin#%E4%B8%BA%E4%BB%80%E4%B9%88%E6%B2%A1%E6%9C%89-y-w-yu-%E5%87%A0%E4%B8%AA%E5%A3%B0%E6%AF%8D) ）。
+  （ [详细信息](https://github.com/mozillazg/python-pinyin#%E4%B8%BA%E4%BB%80%E4%B9%88%E6%B2%A1%E6%9C%89-y-w-yu-%E5%87%A0%E4%B8%AA%E5%A3%B0%E6%AF%8D) ）。
 
 
 Related Projects


### PR DESCRIPTION
use "go install", ref: https://golang.org/doc/go-get-install-deprecation

closed https://github.com/mozillazg/go-pinyin/issues/58